### PR TITLE
docs: Add contributing information

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ Frontend for https://github.com/alphahorizonio/consumat.io.
 
 🚧 This project is a work-in-progress! Instructions will be added as soon as it is usable. 🚧
 
+## Contributing
+
+To contribute, please use the [GitHub flow](https://guides.github.com/introduction/flow/).
+
+To build and start a development version locally, run the following:
+
+```shell
+$ git clone https://github.com/alphahorizonio/consumat.io-frontend.git
+$ yarn
+$ yarn dev
+```
+
+The frontend should now be available on [http://localhost:3000/](http://localhost:3000/). Whenever you change a source file, the frontend will automatically be re-compiled.
+
 ## License
 
 consumat.io-frontend (c) 2021 Felix Pojtinger and contributors


### PR DESCRIPTION
This adds basic contributing docs (see https://github.com/alphahorizonio/consumat.io/issues/10)