### PR TITLE
feat: Improve navbar

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,7 +1,12 @@
+import { ReactNode } from "react";
 import MetaData from "./MetaData";
 import Navbar from "./Navbar";
 
-const Layout = ({ children }) => {
+type LayoutProps = {
+  children: ReactNode;
+};
+
+const Layout = ({ children }: LayoutProps) => {
   return (
     <>
       <MetaData />

--- a/components/MetaData.tsx
+++ b/components/MetaData.tsx
@@ -1,6 +1,12 @@
 import Head from "next/head";
 
-const MetaData = ({ title, keywords, description }) => {
+type MetaDataProps = {
+  title: string;
+  keywords: string;
+  description: string;
+};
+
+const MetaData = ({ title, keywords, description }: MetaDataProps) => {
   return (
     <Head>
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,14 +1,28 @@
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { useState, useEffect } from "react";
 import styles from "../styles/Navbar.module.css";
 
+enum NavigationLink {
+  Home,
+  Discover,
+  Library,
+  Search,
+}
+
 const Navbar = () => {
+  const router = useRouter();
   const [windowWidth, setWindowWidth] = useState<number>(null);
   const [isMobile, setMobile] = useState(true);
   const [isMobileNavbarActive, setMobileNavbarActive] = useState(false);
+  const [
+    activeNavigationLink,
+    setActiveNavigationLink,
+  ] = useState<NavigationLink>(NavigationLink.Home);
 
   useEffect(() => {
     setWindowWidth(window.innerWidth);
+    setActiveNavigationLink(getNavigationLinkForUrl(router.pathname));
 
     function handleResize() {
       setWindowWidth(window.innerWidth);
@@ -22,11 +36,29 @@ const Navbar = () => {
   }, []);
 
   useEffect(() => {
+    router.events.on("routeChangeComplete", (url: string) => {
+      setActiveNavigationLink(getNavigationLinkForUrl(url));
+    });
+  }, []);
+
+  useEffect(() => {
     if (windowWidth === null) return;
     windowWidth < 768 ? setMobile(true) : setMobile(false);
-    console.log(`Current width: ${windowWidth}`);
-    console.log(`Is mobile? ${isMobile}`);
   }, [windowWidth]);
+
+  const getNavigationLinkForUrl = (url: string): NavigationLink | null => {
+    if (url === "/") {
+      return NavigationLink.Home;
+    } else if (url.includes("/discover")) {
+      return NavigationLink.Discover;
+    } else if (url.includes("/library")) {
+      return NavigationLink.Library;
+    } else if (url.includes("/search")) {
+      return NavigationLink.Search;
+    } else {
+      return null;
+    }
+  };
 
   return (
     <div>
@@ -44,17 +76,44 @@ const Navbar = () => {
 
           {!isMobile && (
             <ul className="flex text-xl">
-              <li className={styles.navigationItem}>
-                <Link href="/">Home</Link>
+              <li
+                className={`${styles.navigationLink} ${styles.navigationItem} ${
+                  activeNavigationLink === NavigationLink.Home && styles.active
+                }`}
+              >
+                <Link href="/">
+                  <a>Home</a>
+                </Link>
               </li>
-              <li className={styles.navigationItem}>
-                <Link href="/discover">Discover</Link>
+              <li
+                className={`${styles.navigationLink} ${styles.navigationItem} ${
+                  activeNavigationLink === NavigationLink.Discover &&
+                  styles.active
+                }`}
+              >
+                <Link href="/discover">
+                  <a>Discover</a>
+                </Link>
               </li>
-              <li className={styles.navigationItem}>
-                <Link href="/library">Library</Link>
+              <li
+                className={`${styles.navigationLink} ${styles.navigationItem} ${
+                  activeNavigationLink === NavigationLink.Library &&
+                  styles.active
+                }`}
+              >
+                <Link href="/library">
+                  <a>Library</a>
+                </Link>
               </li>
-              <li className={styles.navigationItem}>
-                <Link href="/search">Search</Link>
+              <li
+                className={`${styles.navigationLink} ${styles.navigationItem} ${
+                  activeNavigationLink === NavigationLink.Search &&
+                  styles.active
+                }`}
+              >
+                <Link href="/search">
+                  <a>Search</a>
+                </Link>
               </li>
             </ul>
           )}
@@ -87,17 +146,50 @@ const Navbar = () => {
               isMobileNavbarActive ? "flex" : "hidden"
             } flex-col text-xl items-center mb-4`}
           >
-            <li className={styles.navigationItemMobile}>
-              <Link href="/">Home</Link>
+            <li
+              className={`${styles.navigationLink} ${
+                styles.navigationItemMobile
+              } ${
+                activeNavigationLink === NavigationLink.Home && styles.active
+              }`}
+            >
+              <Link href="/">
+                <a onClick={() => setMobileNavbarActive(false)}>Home</a>
+              </Link>
             </li>
-            <li className={styles.navigationItemMobile}>
-              <Link href="/discover">Discover</Link>
+            <li
+              className={`${styles.navigationLink} ${
+                styles.navigationItemMobile
+              } ${
+                activeNavigationLink === NavigationLink.Discover &&
+                styles.active
+              }`}
+            >
+              <Link href="/discover">
+                <a onClick={() => setMobileNavbarActive(false)}>Discover</a>
+              </Link>
             </li>
-            <li className={styles.navigationItemMobile}>
-              <Link href="/library">Library</Link>
+            <li
+              className={`${styles.navigationLink} ${
+                styles.navigationItemMobile
+              } ${
+                activeNavigationLink === NavigationLink.Library && styles.active
+              }`}
+            >
+              <Link href="/library">
+                <a onClick={() => setMobileNavbarActive(false)}>Library</a>
+              </Link>
             </li>
-            <li className={styles.navigationItemMobile}>
-              <Link href="/search">Search</Link>
+            <li
+              className={`${styles.navigationLink} ${
+                styles.navigationItemMobile
+              } ${
+                activeNavigationLink === NavigationLink.Search && styles.active
+              }`}
+            >
+              <Link href="/search">
+                <a onClick={() => setMobileNavbarActive(false)}>Search</a>
+              </Link>
             </li>
           </ul>
         )}

--- a/styles/Navbar.module.css
+++ b/styles/Navbar.module.css
@@ -1,28 +1,27 @@
-.navigationItem {
+.navigationLink {
   @apply text-center;
   @apply text-gray-400;
   @apply font-bold;
-  @apply mx-4;
   @apply cursor-pointer;
   @apply border-b-4;
   @apply border-transparent;
 }
 
+.navigationItem {
+  @apply mx-4;
+}
+
+.navigationItem.active,
 .navigationItem:hover {
   @apply border-gray-800;
   @apply text-gray-800;
 }
 
 .navigationItemMobile {
-  @apply text-center;
-  @apply text-gray-400;
-  @apply font-bold;
-  @apply cursor-pointer;
-  @apply border-b-4;
-  @apply border-transparent;
   @apply my-4;
 }
 
+.navigationItemMobile.active,
 .navigationItemMobile:hover {
   @apply border-gray-50;
   @apply text-gray-50;


### PR DESCRIPTION
Closes alphahorizonio/consumat.io#42, closes alphahorizonio/consumat.io#43, closes alphahorizonio/consumat.io#44;

The navbar now displays which site is currently active. Furthermore it now closes when selecting a navbar item on mobile. I also added types for the `Layout` and `MetaData` props. 